### PR TITLE
Check to prevent crashing with modded entities

### DIFF
--- a/src/main/java/com/chailotl/particular/mixin/InjectEntity.java
+++ b/src/main/java/com/chailotl/particular/mixin/InjectEntity.java
@@ -86,6 +86,8 @@ public abstract class InjectEntity
 
 		if (!foundSurface) { return; }
 
+		if (velocities.size() < 2) { return; }
+
 		// 3D splash
 		getWorld().addParticle(Particles.WATER_SPLASH_EMITTER, getX(), baseY + prevState.getHeight(), getZ(), dimensions.width, Collections.max(velocities), 0.0);
 	}


### PR DESCRIPTION
Added a check to prevent certain modded entities from causing the game to crash when trying to create splash particles. This crash mainly occurred with modded throwable item entities, such as the glow sticks from the Spelunkery mod and bombs from Supplementaries.